### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dyroneteng/1f13f4cc-e1db-4620-a419-b3bcf9841dfc/28520d3e-e967-4502-9408-fff0ac8838dd/_apis/work/boardbadge/96d311c2-d211-43fc-a6e3-ae948c76572d)](https://dev.azure.com/dyroneteng/1f13f4cc-e1db-4620-a419-b3bcf9841dfc/_boards/board/t/28520d3e-e967-4502-9408-fff0ac8838dd/Microsoft.RequirementCategory)
 # algorithm
 test
 test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Board Status](https://dev.azure.com/dyroneteng/1f13f4cc-e1db-4620-a419-b3bcf9841dfc/28520d3e-e967-4502-9408-fff0ac8838dd/_apis/work/boardbadge/96d311c2-d211-43fc-a6e3-ae948c76572d)](https://dev.azure.com/dyroneteng/1f13f4cc-e1db-4620-a419-b3bcf9841dfc/_boards/board/t/28520d3e-e967-4502-9408-fff0ac8838dd/Microsoft.RequirementCategory)
 # algorithm
-test
-test
-dsadsadsadasdasd
+1
+2
+3
+4


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/dyroneteng/1f13f4cc-e1db-4620-a419-b3bcf9841dfc/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.